### PR TITLE
Add in-context neural scaling paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,16 +88,11 @@ Figure 4: Key techniques in using LLMs for tabular data. The dotted line indicat
 
 #### Time series 
 
+**[LLMs learn governing principles of dynamical systems, revealing an in-context neural scaling law](https://arxiv.org/abs/2402.00795)**
+
 **[PromptCast: A New Prompt-based Learning Paradigm for Time Series Forecasting](https://arxiv.org/abs/2210.08964)**   
 
-
-
-
 **[Large Language Models Are Zero-Shot Time Series Forecasters](https://arxiv.org/abs/2310.07820)**  
-
-
-
-
 **[TEST: Text Prototype Aligned Embedding to Activate LLM's Ability for Time Series](https://arxiv.org/abs/2308.08241)**  
 
 


### PR DESCRIPTION
This paper tests LLaMA-2 on synthetic time-series data with well-defined transition rules, and observes that the accuracy of the learned transition rules increases with the length of the input context window, revealing an in-context version of neural scaling law.

This paper also presents hierarchy-PDF, a flexible and efficient algorithm for extracting probability density functions of multi-digit numbers directly from LLMs, which may be relevant to the survey.