### PR TITLE
Add DBCopilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ Knowledge Grounding
 **[C3: Zero-shot Text-to-SQL with ChatGPT](https://arxiv.org/abs/2307.07306)**
 **[[code](https://github.com/bigbigwatermalon/C3SQL)]**
 
+**[DBCopilot: Scaling Natural Language Querying to Massive Databases](https://arxiv.org/abs/2312.03463)**
+**[[code](https://github.com/tshu-w/DBCopilot?tab=readme-ov-file)]**
+
 **[Bridging the Gap: Deciphering Tabular Data Using Large Language Model](https://arxiv.org/abs/2308.11891)**
 
 **[TableQuery: Querying tabular data with natural language](https://arxiv.org/abs/2202.00454)**


### PR DESCRIPTION
You are much appreciate if you could add this work after the last sentence of Retrieval-augmented generation (RAG) in page 12:

> \citet{DBCopilot} proposed a DBCopilot framework for scaling Text2SQL to massive databases. DBCopilot leverages a generative copilot model to route natural language queries to target schema (databases and tables) in a relation-aware joint retrieval manner.
